### PR TITLE
index.js now exports the module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require('./src/convex-hull.js');
+module.exports = convexHull = require('./src/convex-hull.js');


### PR DESCRIPTION
`./index.js` wasn't exporting anything, therefore, nothing was there to `require` or `import`. Now there is.